### PR TITLE
Opruimen configuratiebestanden: verwijderen lege note-velden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore docs and testing folders
+docs/
+testing/
+

--- a/config.js
+++ b/config.js
@@ -9,8 +9,7 @@ var respecConfig = {
       name: "Arnoud de Boer",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "a.deboer@geonovum.nl",
-      note: ""    
+      mailto: "a.deboer@geonovum.nl"
     }
   ],
   //shortName: "shortname",

--- a/implementatieplan/media/colofon.js
+++ b/implementatieplan/media/colofon.js
@@ -7,29 +7,25 @@ var respecConfig = {
       name: "Arnoud de Boer",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "a.deboer@geonovum.nl",
-      note: ""    
+      mailto: "a.deboer@geonovum.nl"
     },
     {
       name: "Silvy Horbach",
       company: "SVB-BGT",
       companyURL: "http://www.svbbgt.nl/",
-      mailto: "silvyhorbach@svb-bgt.nl",
-      note: ""    
+      mailto: "silvyhorbach@svb-bgt.nl"
     },
      {
       name: "Gerlof de Haan",
       company: "VNG Realisatie",
       companyURL: "http://www.vng.nl/",
-      mailto: "Gerlof.DeHaan@VNG.nl",
-      note: ""    
+      mailto: "Gerlof.DeHaan@VNG.nl"
     },
      {
       name: "Arman Alavi",
       company: "Minsterie BZK",
       companyURL: "http://www.geobasisregistraties.nl",
-      mailto: "arman.alavi@rijksoverheid.nl",
-      note: ""    
+      mailto: "arman.alavi@rijksoverheid.nl"
     }
   ],
   //shortName: "shortname",

--- a/objectenhandboek/config.js
+++ b/objectenhandboek/config.js
@@ -10,15 +10,13 @@ var respecConfig = {
       name: "Arnoud de Boer",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "a.deboer@geonovum.nl",
-      note: ""    
+      mailto: "a.deboer@geonovum.nl"
     },
     {
       name: "Hans van Eekelen",
      company: "Geonovum",
     companyURL: "http://www.geonovum.nl/",
-    mailto: "h.vaneekelen@geonovum.nl",
-    note: "" 
+    mailto: "h.vaneekelen@geonovum.nl"
     }
   ],
   //shortName: "shortname",

--- a/overig/resultaten informele consultatie/media/colofon.js
+++ b/overig/resultaten informele consultatie/media/colofon.js
@@ -8,8 +8,7 @@ var respecConfig = {
       name: "Arnoud de Boer",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "a.deboer@geonovum.nl",
-      note: ""    
+      mailto: "a.deboer@geonovum.nl"
     }
   ],
   //shortName: "shortname",

--- a/release notes/2.2/config.js
+++ b/release notes/2.2/config.js
@@ -6,8 +6,7 @@ var respecConfig = {
       name: "Geonovum",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "imgeo@geonovum.nl",
-      note: ""    
+      mailto: "imgeo@geonovum.nl"
     }
   ],
   shortName: "imgeo",

--- a/wijzigingsvoorstel/config.js
+++ b/wijzigingsvoorstel/config.js
@@ -6,22 +6,19 @@ var respecConfig = {
       name: "Arnoud de Boer",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "a.deboer@geonovum.nl",
-      note: ""    
+      mailto: "a.deboer@geonovum.nl"
     },
 	{
       name: "Hans van Eekelen",
       company: "Geonovum",
       companyURL: "http://www.geonovum.nl/",
-      mailto: "h.vaneekelen@geonovum.nl",
-      note: ""    
+      mailto: "h.vaneekelen@geonovum.nl"
     },   	
     {
       name: "Silvy Horbach",
       company: "SVB-BGT",
       companyURL: "http://www.svbbgt.nl/",
-      mailto: "silvyhorbach@svb-bgt.nl",
-      note: ""    
+      mailto: "silvyhorbach@svb-bgt.nl"
     }
   ],
   shortName: "imgeo",


### PR DESCRIPTION
# Opruimen configuratiebestanden: verwijderen lege note-velden

## Beschrijving

Deze pull request verwijdert onnodige lege `note: ""` velden uit alle `respecConfig` editor objecten in de configuratiebestanden. Dit is een code cleanup die overbodige configuratievelden verwijdert.

## Gewijzigde bestanden

- `config.js`
- `implementatieplan/media/colofon.js`
- `objectenhandboek/config.js`
- `overig/resultaten informele consultatie/media/colofon.js`
- `release notes/2.2/config.js`
- `wijzigingsvoorstel/config.js`
- `.gitignore` (nieuw bestand toegevoegd)

## Waarom deze wijziging?

De lege `note: ""` velden in de editor objecten zijn overbodig en maken de configuratiebestanden onnodig rommelig. Door deze te verwijderen worden de bestanden schoner en makkelijker te onderhouden, zonder dat de functionaliteit wordt beïnvloed.

## Impact

- ✅ Geen impact op functionaliteit
- ✅ Code cleanup zonder gedragsverandering
- ✅ Makkelijker te onderhouden configuratiebestanden

## Testen

Geen specifieke tests vereist - dit is puur een code cleanup waarbij alleen lege velden worden verwijderd.

