### PR TITLE
Issue #283: Verduidelijken afbakeningsregels voor trottoirbanden

### DIFF
--- a/catalogus/bgt/bgt-10-objectafbakening-ondersteunendwegdeel.md
+++ b/catalogus/bgt/bgt-10-objectafbakening-ondersteunendwegdeel.md
@@ -9,9 +9,10 @@ als fysiek voorkomen de verschillende verhardingssoorten en groenvoorziening.
 ### Regels voor opname
 
 In de regel is dit object scherp begrensd met het aanliggende wegdeel door
-bijvoorbeeld een band of de kant van de verharding. Als een berm bestaat uit een
-deel verhard en een deel begroeid, ontstaan er voor de BGT twee objecten
-OndersteunendWegdeel.
+bijvoorbeeld een band (zoals een trottoirband) of de kant van de verharding.
+Voor trottoirbanden geldt dat de objectbegrenzing samenvalt met de
+buitenzijde van de band. Als een berm bestaat uit een deel verhard en een deel
+begroeid, ontstaan er voor de BGT twee objecten OndersteunendWegdeel.
 
 De niet-wegdeel begrenzing van een begroeide berm met een aanliggend begroeid
 terrein zal niet altijd even duidelijk herkenbaar zijn. Als begrenzing hanteert

--- a/catalogus/bgt/bgt-10-objectafbakening-wegdeel.md
+++ b/catalogus/bgt/bgt-10-objectafbakening-wegdeel.md
@@ -70,8 +70,15 @@ Molgoten langs wegdelen maken deel uit van dat wegdeel, ook als zij uit een
 andere ver­harding bestaan. De buitenzijde van de molgoot vormt de begrenzing
 van het wegdeel met vrijwel gelijke hoogte.
 
-Een afsluitende band hoort bij het wegdeel, verkeerseiland of berm dat gelijk
-ligt met de bovenzijde van de band.
+Een afsluitende band (zoals een trottoirband) hoort bij het wegdeel,
+verkeerseiland of berm dat gelijk ligt met de bovenzijde van de band. De
+objectbegrenzing valt samen met de buitenzijde van de band (aan de kant van het
+object waar de band bij hoort). Als een trottoirband een scheiding vormt tussen
+een wegdeel en een berm of onbegroeid terreindeel, dan hoort de band bij het
+wegdeel indien de bovenzijde van de band gelijk ligt met het wegdek. Als de
+bovenzijde van de band gelijk ligt met het niveau van de berm of het
+onbegroeid terreindeel, dan hoort de band bij het ondersteunend wegdeel
+respectievelijk onbegroeid terreindeel.
 
 Fietspaden vormen BGT inhoud indien aangeduid met een blauw bord met daarop een
 wit rijwiel (bord G11 of G12a), of een blauw of zwart bord met daarop de tekst

--- a/issues/283_trottoirbanden.md
+++ b/issues/283_trottoirbanden.md
@@ -1,0 +1,40 @@
+# Issue 283: Verduidelijken afbakeningsregels trottoirbanden
+
+**Ingediend door:** s.horbach (s.horbach@geonovum.nl)  
+**Rol:** Bronhouder  
+**Namens:** Bronhouders  
+**Datum:** [datum]
+
+## Beschrijving
+
+Betere afbakeningsregel, of verduidelijken tav trottoirbanden.
+
+## Gerelateerde tickets
+
+- SDIMGEO-51
+- SDIMGEO-80
+
+## Impact
+
+Lage impact, alleen verduidelijken van bestaande regels.
+
+## Huidige situatie
+
+In de afbakeningsregels voor wegdeel staat:
+> Een afsluitende band hoort bij het wegdeel, verkeerseiland of berm dat gelijk ligt met de bovenzijde van de band.
+
+Voor ondersteunend wegdeel staat:
+> In de regel is dit object scherp begrensd met het aanliggende wegdeel door bijvoorbeeld een band of de kant van de verharding.
+
+Deze regels zijn onduidelijk voor bronhouders bij het afbakenen van trottoirbanden.
+
+## Gewenste wijziging
+
+Verduidelijken van de afbakeningsregels voor trottoirbanden zodat duidelijk is:
+- Waar de begrenzing wordt gelegd (bijv. aan de voet, bovenzijde, of hart van de band)
+- Hoe om te gaan met trottoirbanden tussen wegdeel en berm/ondersteunend wegdeel
+- Hoe om te gaan met trottoirbanden tussen wegdeel en onbegroeid terreindeel
+
+## Status
+
+Openstaand - in behandeling

--- a/objectenhandboek/101 wegdeel.md
+++ b/objectenhandboek/101 wegdeel.md
@@ -81,8 +81,15 @@ Bron: [Gegevenscatalogus BGT 1.2](https://docs.geostandaarden.nl/imgeo/catalogus
 >   andere ver­harding bestaan. De buitenzijde van de molgoot vormt de
 >   begrenzing van het wegdeel met vrijwel gelijke hoogte.
 >
->   Een afsluitende band hoort bij het wegdeel, verkeerseiland of berm dat
->   gelijk ligt met de bovenzijde van de band.
+>   Een afsluitende band (zoals een trottoirband) hoort bij het wegdeel,
+>   verkeerseiland of berm dat gelijk ligt met de bovenzijde van de band. De
+>   objectbegrenzing valt samen met de buitenzijde van de band (aan de kant van het
+>   object waar de band bij hoort). Als een trottoirband een scheiding vormt tussen
+>   een wegdeel en een berm of onbegroeid terreindeel, dan hoort de band bij het
+>   wegdeel indien de bovenzijde van de band gelijk ligt met het wegdek. Als de
+>   bovenzijde van de band gelijk ligt met het niveau van de berm of het
+>   onbegroeid terreindeel, dan hoort de band bij het ondersteunend wegdeel
+>   respectievelijk onbegroeid terreindeel.
 >
 >   Fietspaden vormen BGT inhoud indien aangeduid met een blauw bord met daarop
 >   een wit rijwiel (bord G11 of G12a), of een blauw of zwart bord met daarop de

--- a/objectenhandboek/102 ondersteunendwegdeel.md
+++ b/objectenhandboek/102 ondersteunendwegdeel.md
@@ -19,9 +19,10 @@ Bron: [Gegevenscatalogus BGT 1.2](https://docs.geostandaarden.nl/imgeo/catalogus
 >   **Regels voor opname**
 >   
 >   In de regel is dit object scherp begrensd met het aanliggende wegdeel door
->   bijvoorbeeld een band of de kant van de verharding. Als een berm bestaat uit
->   een deel verhard en een deel begroeid, ontstaan er voor de BGT twee objecten
->   OndersteunendWegdeel.
+>   bijvoorbeeld een band (zoals een trottoirband) of de kant van de verharding.
+>   Voor trottoirbanden geldt dat de objectbegrenzing samenvalt met de
+>   buitenzijde van de band. Als een berm bestaat uit een deel verhard en een deel
+>   begroeid, ontstaan er voor de BGT twee objecten OndersteunendWegdeel.
 >   
 >   De niet-wegdeel begrenzing van een begroeide berm met een aanliggend
 >   begroeid terrein zal niet altijd even duidelijk herkenbaar zijn. Als


### PR DESCRIPTION
## Beschrijving

Dit PR verduidelijkt de afbakeningsregels voor trottoirbanden in de BGT catalogus en objectenhandboek.

## Wijzigingen

- Verduidelijkt regel voor afsluitende band/trottoirband in wegdeel afbakening
- Toegevoegd dat objectbegrenzing samenvalt met buitenzijde van de band
- Verduidelijkt wanneer trottoirband bij wegdeel, berm of onbegroeid terreindeel hoort
- Zelfde verduidelijking toegevoegd aan ondersteunendwegdeel afbakening
- Objectenhandboek bijgewerkt om consistent te zijn met catalogus
- Issue documentatie toegevoegd

## Issue

- Issue #283
- Ingediend door: s.horbach (s.horbach@geonovum.nl) namens bronhouders
- Gerelateerd aan: SDIMGEO-51, SDIMGEO-80

## Impact

Lage impact - alleen verduidelijking van bestaande regels.